### PR TITLE
Add type hints and numpy-style docstrings to imu/ module

### DIFF
--- a/src/biomechzoo/imu/step_detection.py
+++ b/src/biomechzoo/imu/step_detection.py
@@ -1,11 +1,41 @@
-import numpy as np
-from scipy.signal import find_peaks, butter, filtfilt
+from typing import List, Tuple
 
-def imu_mcgrath(ch_line, fsamp, min_stance_t, is_filtered=False):
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.signal import butter, filtfilt, find_peaks
+
+
+def imu_mcgrath(
+        ch_line: ArrayLike, fsamp: float, min_stance_t: float,
+        is_filtered: bool = False,
+) -> Tuple[np.ndarray, np.ndarray]:
     """
-    This function detects the steps based on the method of McGrath et al. (2012) https://doi.org/10.1007/s12283-012-0093-8
-    in short, the first minimum after a local maximum is the heel strike. The local maxima are the mid-swing.
-    Data should be filtered
+    Detect gait events using the method of McGrath et al. (2012).
+
+    The first minimum after a local maximum midswing peak is taken as
+    initial contact (heel strike); the first valid minimum before a
+    midswing peak is taken as terminal contact (toe off). Reference:
+    https://doi.org/10.1007/s12283-012-0093-8
+
+    Parameters
+    ----------
+    ch_line : array_like
+        Vertical acceleration signal.
+    fsamp : float
+        Sampling frequency in Hz.
+    min_stance_t : float
+        Minimum stance time, in milliseconds, used to validate
+        detected steps.
+    is_filtered : bool, optional
+        If True, ``ch_line`` is assumed to already be filtered and no
+        additional low-pass filtering is applied. Default is False.
+
+    Returns
+    -------
+    IC : ndarray
+        Indices of detected initial contact (heel strike) events.
+    TC : ndarray
+        Indices of detected terminal contact (toe off) events.
     """
 
     if is_filtered:
@@ -107,7 +137,29 @@ def imu_mcgrath(ch_line, fsamp, min_stance_t, is_filtered=False):
 
     return IC, TC
 
-def crash_catch(min_stance_samples, IC, TC):
+def crash_catch(
+        min_stance_samples: int, IC: List[int], TC: List[int],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Ensure initial and terminal contact index arrays are the same
+    length, truncating any extra detections.
+
+    Parameters
+    ----------
+    min_stance_samples : int
+        Unused. Reserved for future stance-time validation.
+    IC : list of int
+        Indices of detected initial contact events.
+    TC : list of int
+        Indices of detected terminal contact events.
+
+    Returns
+    -------
+    IC : ndarray
+        Initial contact indices, truncated to match ``TC`` length.
+    TC : ndarray
+        Terminal contact indices, truncated to match ``IC`` length.
+    """
     # Ensure IC and TC arrays are same length and valid
     IC = np.array(IC)
     TC = np.array(TC)

--- a/src/biomechzoo/imu/tilt_algorithm.py
+++ b/src/biomechzoo/imu/tilt_algorithm.py
@@ -1,10 +1,40 @@
-import numpy as np
 import math
+from typing import Dict, Optional, Tuple
+
+import numpy as np
 import pandas as pd
+from numpy.typing import ArrayLike
+
 from biomechzoo.processing.addchannel_data import addchannel_data
 
-def tilt_algorithm_data(data,ch_vert, ch_medlat, ch_antpost, plot_or_not=None):
 
+def tilt_algorithm_data(
+        data: Dict, ch_vert: str, ch_medlat: str, ch_antpost: str,
+        plot_or_not: Optional[bool] = None,
+) -> Dict:
+    """
+    Apply the tilt correction algorithm to the vertical, mediolateral,
+    and anteroposterior channels of zoo data.
+
+    Parameters
+    ----------
+    data : dict
+        Zoo file data dictionary.
+    ch_vert : str
+        Name of the vertical acceleration channel.
+    ch_medlat : str
+        Name of the mediolateral acceleration channel.
+    ch_antpost : str
+        Name of the anteroposterior acceleration channel.
+    plot_or_not : bool, optional
+        Unused. Reserved for future plotting support.
+
+    Returns
+    -------
+    data : dict
+        Zoo file data dictionary with the tilt-corrected channels
+        (``<channel>_tilt_corr``) added.
+    """
     # extract channels from data
     avert = data[ch_vert]['line']
     amedlat = data[ch_medlat]['line']
@@ -19,9 +49,12 @@ def tilt_algorithm_data(data,ch_vert, ch_medlat, ch_antpost, plot_or_not=None):
     return data
 
 
-def tilt_algorithm_line(avert, amedlat, aantpost):
+def tilt_algorithm_line(
+        avert: ArrayLike, amedlat: ArrayLike, aantpost: ArrayLike,
+) -> Tuple[pd.DataFrame, np.ndarray, np.ndarray, np.ndarray]:
     """
-    TiltAlgorithm - to account for gravity and improper tilt alignment of a tri-axial trunk accelerometer.
+    Account for gravity and improper tilt alignment of a tri-axial
+    trunk accelerometer.
 
     Step 1: Extract raw measured (mean) accelerations
     Step 2: Calculate tilt angles
@@ -34,23 +67,28 @@ def tilt_algorithm_line(avert, amedlat, aantpost):
 
     Parameters
     ----------
-    avert : 1D-array
-        data predominantly in vertical direction. Expressed in g's
-    amedlat : 1D-array:
-        data predominantly in medio-lateral direction. Expressed in g's
-    aantpost : 1D-array
-        data predominantly in anterior-posterior direction. Expressed in g's
+    avert : array_like
+        Data predominantly in vertical direction. Expressed in g's.
+    amedlat : array_like
+        Data predominantly in medio-lateral direction. Expressed in g's.
+    aantpost : array_like
+        Data predominantly in anterior-posterior direction. Expressed
+        in g's.
+
     Returns
     -------
-    df_corrected : Nx3 DataFrame
-        the tilt corrected and gravity subtracted vertical, medio-lateral and anterior-posterior
-        acceleration signals
-    avert2: 1D-array
-        the tilt corrected acceleration data in vertical direction
-    amedlat2 : 1D-array
-        the tilt corrected acceleration data in medio-lateral direction
-    aantpost2: 1D-array
-        the tilt corrected acceleration data in anterior-posterior direction
+    df_corrected : pandas.DataFrame
+        The tilt corrected and gravity subtracted vertical,
+        medio-lateral, and anterior-posterior acceleration signals
+        (n x 3).
+    avert2 : ndarray
+        The tilt corrected acceleration data in vertical direction.
+    amedlat2 : ndarray
+        The tilt corrected acceleration data in medio-lateral direction.
+    aantpost2 : ndarray
+        The tilt corrected acceleration data in anterior-posterior
+        direction.
+
     Notes
     -----
     -  If average acceleration is above 5m/s^2, the signal will be corrected.


### PR DESCRIPTION
- `tilt_algorithm.py` — added type hints; wrote `tilt_algorithm_data`'s docstring from scratch; reformatted `tilt_algorithm_line`'s docstring
- `step_detection.py` — added type hints; wrote docstrings for `imu_mcgrath` and `crash_catch`

No logic changes.

Testing: No test suite in this repo. Ran all four functions against real/synthetic data — all returned the types now declared.