### PR TITLE
Add type hints and numpy-style docstrings to utils/ module

### DIFF
--- a/src/biomechzoo/utils/batchdisp.py
+++ b/src/biomechzoo/utils/batchdisp.py
@@ -1,11 +1,43 @@
-def batchdisp(msg, level=1, verbose='none'):
-    """ utility to control verbosity level during batch processing"""
+from typing import Union
+
+
+def batchdisp(
+        msg: str, level: Union[int, str] = 1,
+        verbose: Union[int, str] = 'none',
+) -> None:
+    """
+    Print a message if the verbosity level permits.
+
+    Parameters
+    ----------
+    msg : str
+        Message to print.
+    level : {0, 1, 2, 'none', 'minimal', 'all'}, optional
+        Verbosity level required for ``msg`` to be printed. Default is 1.
+    verbose : {0, 1, 2, 'none', 'minimal', 'all'}, optional
+        Current verbosity setting. ``msg`` is printed when ``verbose``
+        is greater than or equal to ``level``. Default is ``'none'``.
+    """
     level = _normalize_verbose(level)
     verbose = _normalize_verbose(verbose)
     if verbose >= level:
         print(msg)
 
-def _normalize_verbose(verbose):
+
+def _normalize_verbose(verbose: Union[int, str]) -> int:
+    """
+    Normalize a verbosity level to its integer representation.
+
+    Parameters
+    ----------
+    verbose : {0, 1, 2, 'none', 'minimal', 'all'}
+        Verbosity level as an integer or string.
+
+    Returns
+    -------
+    level : int
+        Normalized verbosity level (0, 1, or 2).
+    """
     if isinstance(verbose, int):
         if verbose not in (0, 1, 2):
             raise ValueError("Integer verbose level must be 0 (none), 1 (minimal), or 2 (all)")

--- a/src/biomechzoo/utils/combine_xsens_csv.py
+++ b/src/biomechzoo/utils/combine_xsens_csv.py
@@ -1,18 +1,37 @@
 import os
+from typing import List, Optional
 
 import pandas as pd
 
 
 def combine_quats_to_csv(
-    csv_files: list[str],
-    prefixes: list[str],
-    out_folder: str = None,
-    out_filename: str = None
-    ) -> str:
+        csv_files: List[str], prefixes: List[str],
+        out_folder: Optional[str] = None, out_filename: Optional[str] = None,
+) -> str:
+    """
+    Concatenate time, quaternion, gyroscope, and accelerometer data
+    from multiple CSV files into a single CSV file, with column
+    prefixes identifying each segment.
 
-    """Concatenates time, quaternions, gyroscope, and accelerometer data
-    from multiple CSV files into a single CSV file with prefixes defining segment."""
+    Parameters
+    ----------
+    csv_files : list of str
+        Paths to the input CSV files, one per sensor/segment.
+    prefixes : list of str
+        Column-name prefix to apply for each file in ``csv_files``,
+        identifying the segment (e.g. ``'pelvis'``).
+    out_folder : str, optional
+        Folder (relative to the current working directory) to save
+        the combined CSV to. Default is ``'combined_csvs'``.
+    out_filename : str, optional
+        Name of the combined output CSV file. Default is
+        ``'combined_sensors.csv'``.
 
+    Returns
+    -------
+    out_file : str
+        Full path to the saved combined CSV file.
+    """
     if out_folder is None:
         out_folder = "combined_csvs"
 

--- a/src/biomechzoo/utils/common_substring.py
+++ b/src/biomechzoo/utils/common_substring.py
@@ -1,4 +1,23 @@
-def common_substring_join(strings):
+from typing import List
+
+
+def common_substring_join(strings: List[str]) -> str:
+    """
+    Join the substrings common to every string in a list of
+    underscore-separated names.
+
+    Parameters
+    ----------
+    strings : list of str
+        Underscore-separated strings to compare, e.g.
+        ``'a_pelvis_antpost_tilt_corr'``.
+
+    Returns
+    -------
+    joined : str
+        Underscore-joined string of the parts shared by every entry
+        in ``strings``, in their original order.
+    """
     # Split each string into parts
     split_lists = [s.split('_') for s in strings]
 
@@ -11,7 +30,9 @@ def common_substring_join(strings):
             # As soon as one position differs, skip but keep checking further ones
             continue
 
-    return "_".join(common_parts)
+    joined = "_".join(common_parts)
+
+    return joined
 
 if __name__ == '__main__':
     # Example

--- a/src/biomechzoo/utils/compute_sampling_rate_from_time.py
+++ b/src/biomechzoo/utils/compute_sampling_rate_from_time.py
@@ -1,7 +1,10 @@
 import numpy as np
+from numpy.typing import ArrayLike
 
 
-def compute_sampling_rate_from_time(t, verbose=False):
+def compute_sampling_rate_from_time(
+        t: ArrayLike, verbose: bool = False,
+) -> int:
     """
     Compute the sampling rate from a time column.
 

--- a/src/biomechzoo/utils/engine.py
+++ b/src/biomechzoo/utils/engine.py
@@ -1,9 +1,16 @@
 import os
+from typing import List, Optional, Union
+
 import numpy as np
 
 
-def engine(root_folder, extension='.zoo', subfolders=None, name_contains=None, name_excludes=None,
-           match_all=False, verbose=False):
+def engine(
+        root_folder: str, extension: str = '.zoo',
+        subfolders: Optional[Union[str, List[str]]] = None,
+        name_contains: Optional[Union[str, List[str]]] = None,
+        name_excludes: Optional[Union[str, List[str]]] = None,
+        match_all: bool = False, verbose: bool = False,
+) -> np.ndarray:
     """
     Recursively search for files with a given extension, with optional filters.
 
@@ -28,8 +35,8 @@ def engine(root_folder, extension='.zoo', subfolders=None, name_contains=None, n
 
     Returns
     -------
-    list of str
-        Sorted list of absolute file paths matching the search criteria.
+    matched_files : ndarray of str
+        Sorted array of absolute file paths matching the search criteria.
     """
 
     # check format of subfolders

--- a/src/biomechzoo/utils/fileparts.py
+++ b/src/biomechzoo/utils/fileparts.py
@@ -1,7 +1,8 @@
 import os
+from typing import Tuple
 
 
-def fileparts(file):
+def fileparts(file: str) -> Tuple[str, str, str]:
     """
     Split a file path into its directory, filename, and extension.
 

--- a/src/biomechzoo/utils/find_repo_root.py
+++ b/src/biomechzoo/utils/find_repo_root.py
@@ -1,19 +1,25 @@
 import os
+from typing import Optional
 
-def find_repo_root(path=None, marker="README.md"):
+
+def find_repo_root(
+        path: Optional[str] = None, marker: str = "README.md",
+) -> str:
     """
     Find the nearest parent directory containing the specified marker file.
 
     Parameters
     ----------
-    path : str. If None, defaults to the current working directory.
-        Starting file or directory.
+    path : str, optional
+        Starting file or directory to search upward from. If None,
+        defaults to this module's file location.
     marker : str, optional
-        File used to identify the repository root. Default README.md
+        File used to identify the repository root. Default is
+        ``'README.md'``.
 
     Returns
     -------
-    str
+    path : str
         Absolute path to the repository root.
 
     Raises

--- a/src/biomechzoo/utils/findfield.py
+++ b/src/biomechzoo/utils/findfield.py
@@ -1,4 +1,11 @@
-def findfield(data, target_event):
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+def findfield(
+        data: Dict, target_event: str,
+) -> Tuple[Optional[np.ndarray], Optional[str]]:
     """
     Search zoo data for the value and channel associated with a target event.
 
@@ -11,7 +18,7 @@ def findfield(data, target_event):
 
     Returns
     -------
-    events : list or None
+    events : ndarray or None
         Event data as ``[frame_index, value, 0]``, or None if not found.
     channel : str or None
         Name of the channel containing the event, or None if not found.

--- a/src/biomechzoo/utils/get_sample_zoo_file.py
+++ b/src/biomechzoo/utils/get_sample_zoo_file.py
@@ -1,12 +1,15 @@
-import numpy as np
 import os
+from typing import Dict
+
+import numpy as np
 from ezc3d import c3d
 
 from biomechzoo.utils.find_repo_root import find_repo_root
 from biomechzoo.utils.zload import zload
 from biomechzoo.conversion.c3d2zoo_data import c3d2zoo_data
 
-def load_sample_zoo_file():
+
+def load_sample_zoo_file() -> Dict:
     """
     Load and return a sample zoo data structure from the repository.
 
@@ -15,7 +18,7 @@ def load_sample_zoo_file():
 
     Returns
     -------
-    dict
+    data : dict
         Zoo-format data structure generated from the sample C3D file.
 
     Raises

--- a/src/biomechzoo/utils/get_split_events.py
+++ b/src/biomechzoo/utils/get_split_events.py
@@ -1,9 +1,31 @@
+from typing import Dict, List, Optional
+
 from biomechzoo.utils.findfield import findfield
 
 
-def get_split_events(data, first_event_name):
-    """ splits lengthy trials containing n cycles into n trials based on side"""
+def get_split_events(data: Dict, first_event_name: str) -> Optional[List[str]]:
+    """
+    Split a lengthy trial containing multiple cycles into per-cycle
+    event names.
 
+    Searches ``data`` for events following the naming pattern
+    ``name1``, ``name2``, etc., starting from ``first_event_name``.
+
+    Parameters
+    ----------
+    data : dict
+        Zoo file data dictionary.
+    first_event_name : str
+        Name of the first event in the numbered sequence
+        (e.g. ``'RFS1'``).
+
+    Returns
+    -------
+    split_events : list of str or None
+        Names of the numbered events found in sequence, or None if
+        the event channel could not be found or fewer than 2 events
+        exist.
+    """
     # find all events, events should follow style name1, name2, etc..
     split_events = []
     _, channel_name = findfield(data, first_event_name)
@@ -27,7 +49,7 @@ def get_split_events(data, first_event_name):
     n_segments = len(split_events) - 1
     if n_segments < 1:
         print("Not enough {} events to split.".format(event_name_root))
-        return
+        return None
 
     return split_events
 

--- a/src/biomechzoo/utils/group_by_terminal_folder.py
+++ b/src/biomechzoo/utils/group_by_terminal_folder.py
@@ -1,10 +1,31 @@
 import os
+from typing import Dict, List
 
-def group_by_terminal_folder(files, root):
+
+def group_by_terminal_folder(
+        files: List[str], root: str,
+) -> Dict[str, List[str]]:
+    """
+    Group file paths by their containing (terminal) folder.
+
+    Parameters
+    ----------
+    files : list of str
+        File paths to group.
+    root : str
+        Unused. Reserved for future path-relativization support.
+
+    Returns
+    -------
+    groups : dict of {str : list of str}
+        Mapping of each unique parent folder to the list of files it
+        contains.
+    """
     groups = {}
     for f in files:
         folder = os.path.dirname(f)
         if folder not in groups:
             groups[folder] = []
         groups[folder].append(f)
+
     return groups

--- a/src/biomechzoo/utils/peak_sign.py
+++ b/src/biomechzoo/utils/peak_sign.py
@@ -1,6 +1,8 @@
 import numpy as np
+from numpy.typing import ArrayLike
 
-def peak_sign(r):
+
+def peak_sign(r: ArrayLike) -> int:
     """
     Determine whether the largest absolute peak in the signal is positive or negative.
 

--- a/src/biomechzoo/utils/set_zoosystem.py
+++ b/src/biomechzoo/utils/set_zoosystem.py
@@ -1,9 +1,10 @@
-import numpy as np
 from pathlib import Path
+from typing import Dict, Optional
+
 from biomechzoo.utils.version import get_biomechzoo_version
 
 
-def set_zoosystem(fl=None):
+def set_zoosystem(fl: Optional[str] = None) -> Dict:
     """
     Create the 'zoosystem' metadata branch for data imported into BiomechZoo.
 
@@ -14,9 +15,10 @@ def set_zoosystem(fl=None):
 
     Returns
     -------
-    dict
-        Dictionary containing default BiomechZoo system parameters including
-        Video, Analog, Anthro, Units, Version, and CompInfo sections.
+    zoosystem : dict
+        Dictionary containing default BiomechZoo system parameters
+        including Video, Analog, Anthro, Units, Version, and CompInfo
+        sections.
     """
 
     # Default top-level fields

--- a/src/biomechzoo/utils/update_channel_list.py
+++ b/src/biomechzoo/utils/update_channel_list.py
@@ -1,4 +1,11 @@
-def update_channel_list(data, section='Video', ch_add=None, ch_remove=None):
+from typing import Dict, List, Optional, Union
+
+
+def update_channel_list(
+        data: Dict, section: str = 'Video',
+        ch_add: Optional[Union[str, List[str]]] = None,
+        ch_remove: Optional[Union[str, List[str]]] = None,
+) -> Dict:
     """
     Update the channel list of a zoosystem section by adding or removing channels.
 
@@ -15,7 +22,7 @@ def update_channel_list(data, section='Video', ch_add=None, ch_remove=None):
 
     Returns
     -------
-    dict
+    data : dict
         The updated zoo dictionary (modified in place).
     """
     ch_list = data['zoosystem'][section]['Channels']

--- a/src/biomechzoo/utils/version.py
+++ b/src/biomechzoo/utils/version.py
@@ -2,4 +2,14 @@ from importlib.metadata import version as get_version
 
 
 def get_biomechzoo_version() -> str:
-    return get_version("biomechzoo")
+    """
+    Get the installed biomechzoo package version.
+
+    Returns
+    -------
+    version : str
+        Installed biomechzoo version string.
+    """
+    version = get_version("biomechzoo")
+
+    return version

--- a/src/biomechzoo/utils/zload.py
+++ b/src/biomechzoo/utils/zload.py
@@ -1,9 +1,33 @@
-from scipy.io import loadmat
 import os
+from typing import Any, Dict
+
 import numpy as np
+from scipy.io import loadmat
 
 
-def zload(filepath):
+def zload(filepath: str) -> Dict:
+    """
+    Load a .zoo file into a zoo data dictionary.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the .zoo file to load.
+
+    Returns
+    -------
+    data : dict
+        Zoo data dictionary, with MATLAB structs converted to nested
+        Python dicts and Video/Analog channel lists converted to
+        Python lists of stripped strings.
+
+    Raises
+    ------
+    ValueError
+        If ``filepath`` does not end in ``'.zoo'``.
+    FileNotFoundError
+        If ``filepath`` does not exist.
+    """
     if not filepath.endswith('.zoo'):
         raise ValueError(f"{filepath} is not a .zoo file")
 
@@ -16,7 +40,7 @@ def zload(filepath):
     mat_data = {k: v for k, v in mat_data.items() if not k.startswith('__')}
 
     # Convert MATLAB structs to Python dicts (recursively)
-    def mat_struct_to_dict(obj):
+    def mat_struct_to_dict(obj: Any) -> Any:
         if isinstance(obj, dict):
             return {k: mat_struct_to_dict(v) for k, v in obj.items()}
         elif hasattr(obj, '_fieldnames'):

--- a/src/biomechzoo/utils/zplot.py
+++ b/src/biomechzoo/utils/zplot.py
@@ -1,7 +1,12 @@
+from typing import Dict
+
 import matplotlib.pyplot as plt
 
 
-def zplot(data, ch, xlabel='frames', ylabel='angles (deg)'):
+def zplot(
+        data: Dict, ch: str, xlabel: str = 'frames',
+        ylabel: str = 'angles (deg)',
+) -> None:
     """
     Plot a single channel of a zoo file, along with any existing events.
 

--- a/src/biomechzoo/utils/zsave.py
+++ b/src/biomechzoo/utils/zsave.py
@@ -1,11 +1,17 @@
-from scipy.io import savemat
 import inspect
 import os
+from typing import Dict, Optional
+
+from scipy.io import savemat
 
 from biomechzoo.utils.batchdisp import batchdisp
 
 
-def zsave(fl, data, inplace=True, out_folder=None, root_folder=None, verbose=False):
+def zsave(
+        fl: str, data: Dict, inplace: bool = True,
+        out_folder: Optional[str] = None, root_folder: Optional[str] = None,
+        verbose: bool = False,
+) -> None:
     """
     Save zoo data to a .zoo file (MATLAB MAT format).
 


### PR DESCRIPTION
Type hints + numpy docstrings across all 18 files in `utils/` (20 functions).

No behavioral changes, aside from making two implicit `return` statements explicit `return None`.

Testing: No test suite in this repo. Ran 19 of 20 functions against real/synthetic data (`load_sample_zoo_file` needs the heavier `ezc3d`/`conversion` pipeline, verified by code-tracing instead). Caught and fixed two real doc bugs this way: `findfield()` and `engine()` were documented as returning `list`, but actually return `numpy.ndarray`.